### PR TITLE
Auto detect and monitor local JVMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,16 @@
 	<url>http://netdata.firehol.org</url>
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
+			<groupId>com.sun</groupId>
+			<artifactId>tools</artifactId>
+			<version>1.4.2</version>
+			<scope>system</scope>
+			<systemPath>${java.home}/../lib/tools.jar</systemPath>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.8.8</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -21,9 +27,10 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-			<version>2.8.8</version>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -54,6 +61,9 @@
 						<manifest>
 							<mainClass>org.firehol.netdata.Main</mainClass>
 						</manifest>
+						<manifestEntries>
+							<Class-Path>${java.home}/../lib/tools.jar</Class-Path>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/src/main/java/org/firehol/netdata/exception/UnreachableCodeException.java
+++ b/src/main/java/org/firehol/netdata/exception/UnreachableCodeException.java
@@ -28,4 +28,11 @@ package org.firehol.netdata.exception;
 public class UnreachableCodeException extends RuntimeException {
 	private static final long serialVersionUID = 9126523210158499016L;
 
+	public UnreachableCodeException() {
+		super();
+	}
+
+	public UnreachableCodeException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/src/main/java/org/firehol/netdata/plugin/jmx/configuration/JmxPluginConfiguration.java
+++ b/src/main/java/org/firehol/netdata/plugin/jmx/configuration/JmxPluginConfiguration.java
@@ -27,6 +27,8 @@ import lombok.Setter;
 @Getter
 @Setter
 public class JmxPluginConfiguration {
+	private boolean autoMonitorLocalVirtualMachines = true;
+
 	private List<JmxServerConfiguration> jmxServers = new ArrayList<>();
 
 	private List<JmxChartConfiguration> commonCharts = new ArrayList<>();

--- a/src/main/java/org/firehol/netdata/plugin/jmx/exception/JmxMBeanServerQueryException.java
+++ b/src/main/java/org/firehol/netdata/plugin/jmx/exception/JmxMBeanServerQueryException.java
@@ -19,16 +19,13 @@
 package org.firehol.netdata.plugin.jmx.exception;
 
 /**
- * Errors while querying a MBean
+ * Represents an exception while querying a MBean.
  * 
+ * @since 1.0.0
  * @author Simon Nagl
  */
-public class JmxMBeanServerQueryException extends Exception {
+public class JmxMBeanServerQueryException extends JmxPluginException {
 	private static final long serialVersionUID = 5480135001434254831L;
-
-	public JmxMBeanServerQueryException() {
-		super();
-	}
 
 	public JmxMBeanServerQueryException(String message, Throwable cause) {
 		super(message, cause);
@@ -36,9 +33,5 @@ public class JmxMBeanServerQueryException extends Exception {
 
 	public JmxMBeanServerQueryException(String message) {
 		super(message);
-	}
-
-	public JmxMBeanServerQueryException(Throwable cause) {
-		super(cause);
 	}
 }

--- a/src/main/java/org/firehol/netdata/plugin/jmx/exception/JmxPluginException.java
+++ b/src/main/java/org/firehol/netdata/plugin/jmx/exception/JmxPluginException.java
@@ -18,16 +18,14 @@
 
 package org.firehol.netdata.plugin.jmx.exception;
 
-/**
- * Represents exceptions while initializing a connection to a JxmMBean Server.
- * 
- * @since 1.0.0
- * @author Simon Nagl
- */
-public class JmxMBeanServerConnectionException extends JmxPluginException {
-	private static final long serialVersionUID = -6153969842214336278L;
+public class JmxPluginException extends Exception {
+	private static final long serialVersionUID = -9084555240752421197L;
 
-	public JmxMBeanServerConnectionException(String message, Throwable cause) {
+	public JmxPluginException(String message, Throwable cause) {
 		super(message, cause);
+	}
+
+	public JmxPluginException(String message) {
+		super(message);
 	}
 }

--- a/src/main/java/org/firehol/netdata/plugin/jmx/exception/VirtualMachineConnectionException.java
+++ b/src/main/java/org/firehol/netdata/plugin/jmx/exception/VirtualMachineConnectionException.java
@@ -18,16 +18,14 @@
 
 package org.firehol.netdata.plugin.jmx.exception;
 
-/**
- * Represents exceptions while initializing a connection to a JxmMBean Server.
- * 
- * @since 1.0.0
- * @author Simon Nagl
- */
-public class JmxMBeanServerConnectionException extends JmxPluginException {
-	private static final long serialVersionUID = -6153969842214336278L;
+public class VirtualMachineConnectionException extends JmxPluginException {
+	private static final long serialVersionUID = -4214747861980964583L;
 
-	public JmxMBeanServerConnectionException(String message, Throwable cause) {
-		super(message, cause);
+	public VirtualMachineConnectionException(String message) {
+		super(message);
+	}
+
+	public VirtualMachineConnectionException(String message, Throwable reason) {
+		super(message, reason);
 	}
 }

--- a/src/main/java/org/firehol/netdata/plugin/jmx/utils/VirtualMachineUtils.java
+++ b/src/main/java/org/firehol/netdata/plugin/jmx/utils/VirtualMachineUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2017 Simon Nagl
+ *
+ * netadata-plugin-java-daemon is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.firehol.netdata.plugin.jmx.utils;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.firehol.netdata.utils.LoggingUtils;
+
+import com.sun.tools.attach.VirtualMachine;
+
+/**
+ * Common methods for operation on a {@link VirtualMachine}.
+ * 
+ * There are no instances of this class.
+ * 
+ * @since 1.0.0
+ * @author Simon Nagl
+ */
+public final class VirtualMachineUtils {
+
+	private static final String SERVICE_URL_AGENT_PROPERTY_KEY = "com.sun.management.jmxremote.localConnectorAddress";
+
+	private static final Logger log = Logger.getLogger("org.firehol.netdata.plugin.jmx");
+
+	/**
+	 * Don't let anyone instantiate this class.
+	 */
+	private VirtualMachineUtils() {
+	}
+
+	/**
+	 * Get the JMX ServiceUrl of a virtualMachine.
+	 * 
+	 * If {@code startJMXAgent} is true, try to start the jmxAgent if it is not
+	 * started.
+	 * 
+	 * @param virtualMachine
+	 *            Attached virtual machine to query.
+	 * @param startJMXAgent
+	 *            If true, try to start the jmxAgent if it is not started.
+	 * @return a JMX ServiceUrl which can be used to connect to the VirtualMachine
+	 *         or null if it could not be found.
+	 * @throws IOException
+	 *             Thrown when an IOException occurs while communicating with the
+	 *             virtualMachine.
+	 */
+	public static JMXServiceURL getJMXServiceURL(VirtualMachine virtualMachine, boolean startJMXAgent)
+			throws IOException {
+		JMXServiceURL serviceUrl = getJMXServiceURL(virtualMachine);
+
+		if (!startJMXAgent) {
+			return serviceUrl;
+		}
+
+		if (serviceUrl != null) {
+			return serviceUrl;
+		}
+
+		virtualMachine.startLocalManagementAgent();
+		return getJMXServiceURL(virtualMachine);
+	}
+
+	/**
+	 * Get the JMX ServiceUrl of a virtualMachine.
+	 * 
+	 * @param virtualMachine
+	 *            Attached virtual machine to query.
+	 * @return a JMX ServiceUrl which can be used to connect to the VirtualMachine
+	 *         or null if it could not be found.
+	 * @throws IOException
+	 *             Thrown when an IOException occurs while communicating with the
+	 *             virtualMachine.
+	 */
+	public static JMXServiceURL getJMXServiceURL(VirtualMachine virtualMachine) throws IOException {
+		String serviceUrl = virtualMachine.getAgentProperties().getProperty(SERVICE_URL_AGENT_PROPERTY_KEY);
+
+		if (serviceUrl == null) {
+			return null;
+		}
+
+		try {
+			return new JMXServiceURL(serviceUrl);
+		} catch (Exception e) {
+			log.fine(LoggingUtils.getMessageSupplier("Could not instantiate JMXServiceURL", e));
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/firehol/netdata/utils/LoggingUtils.java
+++ b/src/main/java/org/firehol/netdata/utils/LoggingUtils.java
@@ -48,6 +48,31 @@ public abstract class LoggingUtils {
 		return sb.toString();
 	}
 
+	public static String buildMessage(String... messages) {
+		if (messages.length == 0) {
+			return "";
+		}
+
+		if (messages.length == 1) {
+			return messages[0];
+		}
+
+		// Find String length.
+		int totalLength = 0;
+		for (String message : messages) {
+			totalLength = +message.length();
+		}
+
+		StringBuilder sb = new StringBuilder(totalLength);
+
+		// Build the message
+		for (String message : messages) {
+			sb.append(message);
+		}
+
+		return sb.toString();
+	}
+
 	public static Supplier<String> getMessageSupplier(Throwable reason) {
 		return new Supplier<String>() {
 			@Override
@@ -62,6 +87,15 @@ public abstract class LoggingUtils {
 			@Override
 			public String get() {
 				return buildMessage(message, reason);
+			}
+		};
+	}
+
+	public static Supplier<String> getMessageSupplier(String... messages) {
+		return new Supplier<String>() {
+			@Override
+			public String get() {
+				return buildMessage(messages);
 			}
 		};
 	}

--- a/src/main/java/org/firehol/netdata/utils/StringUtils.java
+++ b/src/main/java/org/firehol/netdata/utils/StringUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Simon Nagl
+ *
+ * netadata-plugin-java-daemon is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.firehol.netdata.utils;
+
+/**
+ * Operations on {@link java.lang.String}.
+ *
+ * @since 1.0.0
+ * @author Simon Nagl
+ * @see java.lang.String
+ */
+public class StringUtils {
+
+	/**
+	 * Don't let anyone instantiate this class.
+	 */
+	private StringUtils() {
+	}
+
+	/**
+	 * Checks if a String is only whitespace, empty ("") or null.
+	 *
+	 * @param string
+	 *            the String to check
+	 * @return {@code true} if the String is blank
+	 */
+	public static boolean isBlank(String string) {
+		int length;
+		if (string == null || (length = string.length()) == 0) {
+			return true;
+		}
+		for (int i = 0; i < length; i++) {
+			if (!Character.isWhitespace(string.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/test/java/org/firehol/netdata/utils/LoggingUtilsTest.java
+++ b/src/test/java/org/firehol/netdata/utils/LoggingUtilsTest.java
@@ -20,6 +20,8 @@ package org.firehol.netdata.utils;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.function.Supplier;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,6 +54,65 @@ public class LoggingUtilsTest {
 		assertEquals(
 				"Could not do it. Reason: Something went wrong. Detail: This is the reason. Detail: Here are the details.",
 				message);
+	}
+
+	@Test
+	public void testBuildMessageStrings() {
+		// Test
+		String message = LoggingUtils.buildMessage("This ", "should ", "be ", "one ", "message.");
+
+		// Verify
+		assertEquals("This should be one message.", message);
+	}
+
+	@Test
+	public void testBuildMessageStringsNoArg() {
+		// Test
+		String message = LoggingUtils.buildMessage();
+
+		// Verify
+		assertEquals("", message);
+	}
+
+	@Test
+	public void testBuildMessageStringsOneArg() {
+		// Test
+		String message = LoggingUtils.buildMessage("One Argument.");
+
+		// Verify
+		assertEquals("One Argument.", message);
+	}
+
+	@Test
+	public void getMessageSupplierThrowable() {
+		// Test
+		Supplier<String> messageSupplier = LoggingUtils.getMessageSupplier(exception);
+
+		// Verify
+		assertEquals("Something went wrong. Detail: This is the reason. Detail: Here are the details.",
+				messageSupplier.get());
+	}
+
+	@Test
+	public void getMessageSupplierStringThrowable() {
+		// Test
+		Supplier<String> messageSupplier = LoggingUtils.getMessageSupplier("Could not do it.", exception);
+
+		// Verify
+		assertEquals(
+				"Could not do it. Reason: Something went wrong. Detail: This is the reason. Detail: Here are the details.",
+				messageSupplier.get());
+
+	}
+
+	public void getMessageSuplierStrings() {
+		// Test
+		Supplier<String> messageSupplier = LoggingUtils.getMessageSupplier("This ", "should ", "be ", "one ",
+				"message.");
+
+		// Verify
+		assertEquals("This should be one message.", messageSupplier.get());
+
 	}
 
 }

--- a/src/test/java/org/firehol/netdata/utils/StringUtilsTest.java
+++ b/src/test/java/org/firehol/netdata/utils/StringUtilsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 Simon Nagl
+ *
+ * netadata-plugin-java-daemon is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.firehol.netdata.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+	@Test
+	public void testIsBlankNull() {
+		assertTrue(StringUtils.isBlank(null));
+	}
+
+	@Test
+	public void testIsBlankEmpty() {
+		assertTrue(StringUtils.isBlank(""));
+	}
+
+	@Test
+	public void testIsBlankWhitespace() {
+		assertTrue(StringUtils.isBlank(" "));
+	}
+
+	@Test
+	public void testIsBlankEmptyFilled() {
+		assertFalse(StringUtils.isBlank("bob"));
+	}
+
+	@Test
+	public void testIsBlankEmptyFilledWithWhitespace() {
+		assertFalse(StringUtils.isBlank("  bob  "));
+	}
+
+}


### PR DESCRIPTION
Closes #26

This adds tools.jar to the class path which contains the [Attach API](http://docs.oracle.com/javase/6/docs/jdk/api/attach/spec/com/sun/tools/attach/package-summary.html) which we use to 
- find out running JVMs
- start (if possible) the JMX agent on that JVM if it is not started
- and connect to that JMX agent.

We use the attribute `Name` of MBean `java.lang:type=Runtime` to identify if we already have a configuration for the found JVM. If that is the case we use the configuration.

## Other small changes.

- Extend LoggingUtils with performant string concatenation builder and supplier.